### PR TITLE
feat: add uuids to subscriptions

### DIFF
--- a/internal/nostr/models.go
+++ b/internal/nostr/models.go
@@ -34,6 +34,7 @@ type Subscription struct {
 	Search        string
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
+	Uuid          string        `gorm:"type:uuid;default:gen_random_uuid()"`
 
 	// TODO: fix an elegant solution to store datatypes
 	IdsString     string
@@ -160,6 +161,6 @@ type SubscriptionRequest struct {
 }
 
 type SubscriptionResponse struct {
-	SubscriptionId uint   `json:"subscription_id"`
+	SubscriptionId string `json:"subscription_id"`
 	WebhookUrl     string `json:"webhookUrl"`
 }

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"sync"
 	"time"
 
@@ -334,7 +333,7 @@ func (svc *Service) SubscriptionHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, SubscriptionResponse{
-		SubscriptionId: subscription.ID,
+		SubscriptionId: subscription.Uuid,
 		WebhookUrl: requestData.WebhookUrl,
 	})
 }
@@ -403,12 +402,10 @@ func (svc *Service) handleSubscription(ctx context.Context, subscription *Subscr
 }
 
 func (svc *Service) StopSubscriptionHandler(c echo.Context) error {
-	id := c.Param("id")
-	uint64Id, _ := strconv.ParseUint(id, 10, 64)
-	subId := uint(uint64Id)
+	uuid := c.Param("id")
 
 	subscription := Subscription{}
-	if err := svc.db.First(&subscription, subId).Error; err != nil {
+	if err := svc.db.Where("uuid = ?", uuid).First(&subscription).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return c.JSON(http.StatusNotFound, ErrorResponse{
 				Message: "subscription does not exist",

--- a/migrations/202404021628_add_uuid_to_subscriptions.go
+++ b/migrations/202404021628_add_uuid_to_subscriptions.go
@@ -1,0 +1,17 @@
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// Add UUID column to subscriptions table
+var _202404021628_add_uuid_to_subscriptions = &gormigrate.Migration{
+	ID: "202404021628_add_uuid_to_subscriptions",
+	Migrate: func(tx *gorm.DB) error {
+		return tx.Exec("ALTER TABLE subscriptions ADD COLUMN uuid UUID DEFAULT gen_random_uuid()").Error
+	},
+	Rollback: func(tx *gorm.DB) error {
+		return tx.Exec("ALTER TABLE subscriptions DROP COLUMN IF EXISTS uuid").Error
+	},
+}

--- a/migrations/migrate.go
+++ b/migrations/migrate.go
@@ -9,6 +9,7 @@ func Migrate(db *gorm.DB) error {
 
 	m := gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
 		_202402161653_initial_migration,
+		_202404021628_add_uuid_to_subscriptions,
 	})
 
 	return m.Migrate()


### PR DESCRIPTION
- Adds uuid column to the subscriptions table
- Subscriptions are now stopped using UUID and not id (making it difficult to delete others' channels)