### PR TITLE
fix datadog issues

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,7 +11,6 @@ import (
 	echologrus "github.com/davrux/echo-logrus/v4"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
-	ddEcho "gopkg.in/DataDog/dd-trace-go.v1/contrib/labstack/echo.v4"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -26,9 +25,8 @@ func main() {
 	echologrus.Logger = svc.Logger
 	e := echo.New()
 	if svc.Cfg.DatadogAgentUrl != "" {
-		tracer.Start(tracer.WithAgentAddr(svc.Cfg.DatadogAgentUrl))
+		tracer.Start(tracer.WithService("http-nostr"))
 		defer tracer.Stop()
-		e.Use(ddEcho.Middleware(ddEcho.WithServiceName("http-nostr")))
 	}
 
 	e.POST("/nip47/info", svc.InfoHandler)

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -66,8 +66,8 @@ func NewService(ctx context.Context) (*Service, error) {
 	var db *gorm.DB
 	var sqlDb *sql.DB
 
-	if os.Getenv("DATADOG_AGENT_URL") != "" {
-		sqltrace.Register("pgx", &stdlib.Driver{}, sqltrace.WithServiceName("nostr-wallet-connect"))
+	if cfg.DatadogAgentUrl != "" {
+		sqltrace.Register("pgx", &stdlib.Driver{}, sqltrace.WithServiceName("http-nostr"))
 		sqlDb, err = sqltrace.Open("pgx", cfg.DatabaseUri)
 		if err != nil {
 			logger.Fatalf("Failed to open DB %v", err)


### PR DESCRIPTION
- Updates service name to http-nostr in db tracing
- Starts tracer using http-nostr service name instead of `WithAgentAddr`