### PR TITLE
fix: tags in subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,30 @@ Notifies about new events matching the filter provided via webhooks.
   "webhookUrl": "https://your.webhook.url"
 }
 ```
+
+#### Response to Webhook URL
+
+```json
+{
+  "id": "a16ycf4a01bcxx........xxxxx",
+  "pubkey": "a16y69effexxxx........xxxxx",
+  "created_at": 1709033612,
+  "kind": 23195,
+  "tags": [
+      [
+          "p",
+          "f490f5xxxxx........xxxxx"
+      ],
+      [
+          "e",
+          "a41aefxxxxx........xxxxx"
+      ]
+  ],
+  "content": <encrypted content>,
+  "sig": <signature>
+}
+```
+
 </details>
 
 ------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Endpoints:  -->
 
 ### Fetch NIP-47 Info
 
-Returns a Pubkey's NIP-47 capabilities (if any).
+Every NWC-enabled wallet has a pubkey according to the NWC specification.
+This `GET` request returns a pubkey's NWC capabilities (if any)
 
 <details>
 <summary>
@@ -23,24 +24,24 @@ Returns a Pubkey's NIP-47 capabilities (if any).
 
 #### Request Body
 
-> | name      |  type     | data type               | description                                                           |
-> |-----------|-----------|-------------------------|-----------------------------------------------------------------------|
-> | relayUrl  |  optional | string           | If no relay is provided, it uses the default relay (wss://relay.getalby.com/v1)  |
-> | walletPubkey  |  required | string   | Pubkey of the NIP-47 Wallet Provider  |
+| name      |  type     | data type               | description                                                           |
+|-----------|-----------|-------------------------|-----------------------------------------------------------------------|
+| relayUrl  |  optional | string           | If no relay is provided, it uses the default relay (wss://relay.getalby.com/v1)  |
+| walletPubkey  |  required | string   | Pubkey of the NWC Wallet Provider  |
 
 #### Response
 
-> ```json
-> {
->   "id": "a16ye1391c22xx........xxxxx",
->   "pubkey": "a16y69effexxxx........xxxxx",
->   "created_at": 1708336682,
->   "kind": 13194,
->   "tags": [],
->   "content": "pay_invoice,pay_keysend,get_balance,get_info,make_invoice,lookup_invoice,list_transactions",
->   "sig": <signature>
-> }
->```
+```json
+{
+  "id": "a16ye1391c22xx........xxxxx",
+  "pubkey": "a16y69effexxxx........xxxxx",
+  "created_at": 1708336682,
+  "kind": 13194,
+  "tags": [],
+  "content": "pay_invoice, pay_keysend, get_balance, get_info, make_invoice, lookup_invoice, list_transactions",
+  "sig": <signature>
+}
+```
 </details>
 
 ------------------------------------------------------------------------------------------
@@ -56,40 +57,59 @@ Returns the response event directly or to the Webhook URL if provided.
 
 #### Request Body
 
-> | name      |  type     | data type               | description                                                           |
-> |-----------|-----------|-------------------------|-----------------------------------------------------------------------|
-> | relayUrl  |  optional | string           | If no relay is provided, it uses the default relay (wss://relay.getalby.com/v1)  |
-> | webhookUrl  |  optional | string         | Webhook URL to publish the response event, returns the event directly if not provided  |
-> | walletPubkey  |  required | string   | Pubkey of the NIP-47 Wallet Provider  |
-> | event  |  required | JSON object ([nostr.Event](https://pkg.go.dev/github.com/nbd-wtf/go-nostr@v0.25.7#Event))  | **Signed** request event  |
+| name      |  type     | data type               | description                                                           |
+|-----------|-----------|-------------------------|-----------------------------------------------------------------------|
+| relayUrl  |  optional | string           | If no relay is provided, it uses the default relay (wss://relay.getalby.com/v1)  |
+| webhookUrl  |  optional | string         | Webhook URL to publish the response event, returns the event directly if not provided  |
+| walletPubkey  |  required | string   | Pubkey of the NWC Wallet Provider  |
+| event  |  required | JSON object (see [example](#event-example))  | **Signed** request event  |
 
+
+#### Event Example
+
+```json
+{
+  "id":"a16ycf4a01bcxx........xxxxx",
+  "pubkey":"a16y69effexxxx........xxxxx",
+  "created_at":1700000021,
+  "kind":23194,
+  "tags":[
+    ["p","a16y6sfa01bcxx........xxxxx"]
+  ],
+  "content": "<encrypted content>",
+  "sig":"<signature>"
+}
+// Source: https://pkg.go.dev/github.com/nbd-wtf/go-nostr@v0.30.0#Event
+```
 
 #### Response (with webhook)
 
-> "webhook received"
+```json
+"webhook received"
+```
 
 #### Response (without webhook)
 
-> ```json
-> {
->   "id": "a16ycf4a01bcxx........xxxxx",
->   "pubkey": "a16y69effexxxx........xxxxx",
->   "created_at": 1709033612,
->   "kind": 23195,
->   "tags": [
->       [
->           "p",
->           "f490f5xxxxx........xxxxx"
->       ],
->       [
->           "e",
->           "a41aefxxxxx........xxxxx"
->       ]
->   ],
->   "content": <encrypted content>,
->   "sig": <signature>
-> }
->```
+```json
+{
+  "id": "a16ycf4a01bcxx........xxxxx",
+  "pubkey": "a16y69effexxxx........xxxxx",
+  "created_at": 1709033612,
+  "kind": 23195,
+  "tags": [
+    [
+      "p",
+      "f490f5xxxxx........xxxxx"
+    ],
+    [
+      "e",
+      "a41aefxxxxx........xxxxx"
+    ]
+  ],
+  "content": <encrypted content>,
+  "sig": <signature>
+}
+```
 </details>
 
 ------------------------------------------------------------------------------------------
@@ -105,21 +125,39 @@ Notifies about new events matching the filter provided via webhooks.
 
 #### Request Body
 
-> | name      |  type     | data type               | description                                                           |
-> |-----------|-----------|-------------------------|-----------------------------------------------------------------------|
-> | relayUrl  |  optional | string           | If no relay is provided, it uses the default relay  |
-> | webhookUrl  |  required | string         | Webhook URL to publish events |
-> | filter  |  required | JSON object ([nostr.Filter](https://pkg.go.dev/github.com/nbd-wtf/go-nostr@v0.25.7#Filter)) | Filters to subscribe to |
+| name      |  type     | data type               | description                                                           |
+|-----------|-----------|-------------------------|-----------------------------------------------------------------------|
+| relayUrl  |  optional | string           | If no relay is provided, it uses the default relay  |
+| webhookUrl  |  required | string         | Webhook URL to publish events |
+| filter  |  required | JSON object (see [example](#filter-example)) | Filters to subscribe to |
 
+
+#### Filter Example
+
+```json
+{
+  "ids": ["id1", "id2"],
+  "kinds": [1,2],
+  "authors": ["author1", "author2"],
+  "since": 1721212121,
+  "until": 1721212121,
+  "limit": 10,
+  "search": "example search",
+  "#tag1": ["value1", "value2"],
+  "#tag2": ["value3"],
+  "#tag3": ["value4", "value5", "value6"],
+}
+// Source: https://pkg.go.dev/github.com/nbd-wtf/go-nostr@v0.30.0#Filter
+```
 
 #### Response
 
-> ```json
-> {
->   "subscription_id": "f370d1fc-x0x0-x0x0-x0x0-8f68fa12f32c",
->   "webhookUrl": "https://your.webhook.url"
-> }
->```
+```json
+{
+  "subscription_id": "f370d1fc-x0x0-x0x0-x0x0-8f68fa12f32c",
+  "webhookUrl": "https://your.webhook.url"
+}
+```
 </details>
 
 ------------------------------------------------------------------------------------------
@@ -135,16 +173,16 @@ Delete previously requested subscriptions.
 
 #### Parameter
 
-> | name      |  type     | data type               | description                                                           |
-> |-----------|-----------|-------------------------|-----------------------------------------------------------------------|
-> | id  |  required | string           | UUID received on subscribing to a relay  |
+| name      |  type     | data type               | description                                                           |
+|-----------|-----------|-------------------------|-----------------------------------------------------------------------|
+| id  |  required | string           | UUID received on subscribing to a relay  |
 
 
 #### Response
 
-> ```json
-> "subscription x stopped"
->```
+```json
+"subscription x stopped"
+```
 </details>
 
 ------------------------------------------------------------------------------------------

--- a/internal/nostr/models.go
+++ b/internal/nostr/models.go
@@ -153,21 +153,10 @@ type NIP47Request struct {
 	SignedEvent  *nostr.Event `json:"event"`
 }
 
-type Filter struct {
-	IDs     []string         `json:"ids,omitempty"`
-	Kinds   []int            `json:"kinds,omitempty"`
-	Authors []string         `json:"authors,omitempty"`
-	Tags    nostr.Tags       `json:"tags,omitempty"`
-	Since   *nostr.Timestamp `json:"since,omitempty"`
-	Until   *nostr.Timestamp `json:"until,omitempty"`
-	Limit   int              `json:"limit,omitempty"`
-	Search  string           `json:"search,omitempty"`
-}
-
 type SubscriptionRequest struct {
-	RelayUrl     string        `json:"relayUrl"`
-	WebhookUrl   string        `json:"webhookUrl"`
-	Filter       *Filter       `json:"filter"`
+	RelayUrl   string        `json:"relayUrl"`
+	WebhookUrl string        `json:"webhookUrl"`
+	Filter     *nostr.Filter `json:"filter"`
 }
 
 type SubscriptionResponse struct {

--- a/internal/nostr/models.go
+++ b/internal/nostr/models.go
@@ -153,10 +153,21 @@ type NIP47Request struct {
 	SignedEvent  *nostr.Event `json:"event"`
 }
 
+type Filter struct {
+	IDs     []string         `json:"ids,omitempty"`
+	Kinds   []int            `json:"kinds,omitempty"`
+	Authors []string         `json:"authors,omitempty"`
+	Tags    nostr.Tags       `json:"tags,omitempty"`
+	Since   *nostr.Timestamp `json:"since,omitempty"`
+	Until   *nostr.Timestamp `json:"until,omitempty"`
+	Limit   int              `json:"limit,omitempty"`
+	Search  string           `json:"search,omitempty"`
+}
+
 type SubscriptionRequest struct {
 	RelayUrl     string        `json:"relayUrl"`
 	WebhookUrl   string        `json:"webhookUrl"`
-	Filter       *nostr.Filter `json:"filter"`
+	Filter       *Filter       `json:"filter"`
 }
 
 type SubscriptionResponse struct {

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -305,11 +305,9 @@ func (svc *Service) SubscriptionHandler(c echo.Context) error {
 		Ids:        &requestData.Filter.IDs,
 		Authors:    &requestData.Filter.Authors,
 		Kinds:      &requestData.Filter.Kinds,
+		Tags:       &requestData.Filter.Tags,
 		Limit:      requestData.Filter.Limit,
 		Search:     requestData.Filter.Search,
-	}
-	if requestData.Filter.Tags != nil {
-		subscription.Tags = &requestData.Filter.Tags
 	}
 	if requestData.Filter.Since != nil {
 		subscription.Since = requestData.Filter.Since.Time()

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -309,15 +309,7 @@ func (svc *Service) SubscriptionHandler(c echo.Context) error {
 		Search:     requestData.Filter.Search,
 	}
 	if requestData.Filter.Tags != nil {
-		result := make(nostr.TagMap)
-		for _, tagArray := range requestData.Filter.Tags {
-			if len(tagArray) > 1 {
-				key := tagArray[0]
-				value := tagArray[1:]
-				result[key] = value
-			}
-		}
-		subscription.Tags = &result
+		subscription.Tags = &requestData.Filter.Tags
 	}
 	if requestData.Filter.Since != nil {
 		subscription.Since = requestData.Filter.Since.Time()

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -305,9 +305,19 @@ func (svc *Service) SubscriptionHandler(c echo.Context) error {
 		Ids:        &requestData.Filter.IDs,
 		Authors:    &requestData.Filter.Authors,
 		Kinds:      &requestData.Filter.Kinds,
-		Tags:       &requestData.Filter.Tags,
 		Limit:      requestData.Filter.Limit,
 		Search:     requestData.Filter.Search,
+	}
+	if requestData.Filter.Tags != nil {
+		result := make(nostr.TagMap)
+    for _, tagArray := range requestData.Filter.Tags {
+      if len(tagArray) > 1 {
+        key := tagArray[0]
+        value := tagArray[1:]
+        result[key] = value
+      }
+    }
+		subscription.Tags = &result
 	}
 	if requestData.Filter.Since != nil {
 		subscription.Since = requestData.Filter.Since.Time()

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -310,13 +310,13 @@ func (svc *Service) SubscriptionHandler(c echo.Context) error {
 	}
 	if requestData.Filter.Tags != nil {
 		result := make(nostr.TagMap)
-    for _, tagArray := range requestData.Filter.Tags {
-      if len(tagArray) > 1 {
-        key := tagArray[0]
-        value := tagArray[1:]
-        result[key] = value
-      }
-    }
+		for _, tagArray := range requestData.Filter.Tags {
+			if len(tagArray) > 1 {
+				key := tagArray[0]
+				value := tagArray[1:]
+				result[key] = value
+			}
+		}
 		subscription.Tags = &result
 	}
 	if requestData.Filter.Since != nil {


### PR DESCRIPTION
Previously we didn't support tags (mistakenly), this fix makes sure tags can be passed alongside the other filter attributes like this
```
{
  "ids": ["id1", "id2"],
  "kinds": [1,2],
  "authors": ["author1", "author2"],
  "since": 1721212121,
  "until": 1721212121,
  "limit": 10,
  "search": "example search",
  "#p": ["g3ta16yxxxxxxx"],
  "#e": ["g3ta16yxxxxxxx"]
}
```