### PR TITLE
fix: change request_id to be nil instead of empty

### DIFF
--- a/internal/nostr/models.go
+++ b/internal/nostr/models.go
@@ -128,7 +128,7 @@ type RequestEvent struct {
 
 type ResponseEvent struct {
 	ID             uint
-	RequestId      uint
+	RequestId      *uint
 	SubscriptionId uint      `validate:"required"`
 	NostrId        string    `validate:"required"`
 	Content        string

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -806,7 +806,7 @@ func (svc *Service) processRequest(ctx context.Context, subscription *Subscripti
 		}).Infof("Successfully received event")
 		responseEvent := ResponseEvent{
 			SubscriptionId: subscription.ID,
-			RequestId:      requestEvent.ID,
+			RequestId:      &requestEvent.ID,
 			NostrId:        event.ID,
 			Content:        event.Content,
 			RepliedAt:      event.CreatedAt.Time(),


### PR DESCRIPTION
## Description

#62 bought this change from `*uint` to `uint` [here](https://github.com/getAlby/http-nostr/pull/62/files#diff-758fcfb783be388d6ceb90959b23a2ae5afa80f0e6ea5c799f8951ff99d3e1f4R131), and that made response events pass uint values instead of NULL causing the Foreign Key constraint violation:

```
2024/05/29 11:30:11 /Users/im-adithya/Coding/opensource/http-nostr-api/internal/nostr/nostr.go:688 ERROR: insert or update on table "response_events" violates foreign key constraint "fk_response_events_request_event" (SQLSTATE 23503)
```