### PR TITLE
fix: relay connection issue

### DIFF
--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -719,7 +719,9 @@ func (svc *Service) getRelayConnection(ctx context.Context, customRelayURL strin
 	} else {
 		svc.Logger.Info("Lost connection to default relay, reconnecting...")
 		relay, err := nostr.RelayConnect(svc.Ctx, svc.Cfg.DefaultRelayURL)
-		svc.Relay = relay
+		if err == nil {
+			svc.Relay = relay
+		}
 		return svc.Relay, false, err
 	}
 }


### PR DESCRIPTION
Without this, the newly re-connected default relay (even though it's not actually connected*) returns `.isConnected()` as `true` and makes the further subscriptions fetching the relay return no error and make them move to the `relay.Subscribe` step which causes the app to panic and crash



*Because recently connected relays take atleast 30s to check if there is a connection error, till then connection error is assumed to be nil