### PR TITLE
chore: close subscriptions everywhere

### DIFF
--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -208,6 +208,7 @@ func (svc *Service) InfoHandler(c echo.Context) error {
 			"walletPubkey": requestData.WalletPubkey,
 			"eventId":      event.ID,
 		}).Info("Received info event")
+		sub.Unsub()
 		return c.JSON(http.StatusOK, InfoResponse{
 			Event: event,
 		})


### PR DESCRIPTION
Right now we depend on echo context closure fr the subscription to end, but this explicitly closes the subscription after receiving the subscribed info event.