### PR TITLE
feat: add exponential backoff to subscriptions

### DIFF
--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -715,7 +715,7 @@ func (svc *Service) startSubscription(ctx context.Context, subscription *Subscri
 			svc.Logger.WithError(err).WithFields(logrus.Fields{
 				"subscription_id": subscription.ID,
 				"relay_url":       subscription.RelayUrl,
-				}).Errorf("Failed to subscribe to relay, retrying in %vs...", waitToReconnectSeconds)
+				}).Errorf("Failed to connect to relay, retrying in %vs...", waitToReconnectSeconds)
 			waitToReconnectSeconds = max(waitToReconnectSeconds, 1)
 			waitToReconnectSeconds = min(waitToReconnectSeconds * 2, 900)
 			continue
@@ -741,6 +741,8 @@ func (svc *Service) startSubscription(ctx context.Context, subscription *Subscri
 			"subscription_id": subscription.ID,
 			"relay_url":       subscription.RelayUrl,
 		}).Debug("Started subscription")
+
+		waitToReconnectSeconds = 0
 
 		err = svc.processEvents(ctx, subscription, onReceiveEOS, handleEvent)
 


### PR DESCRIPTION
- Adds exponential backoff starting from 0s, 2s, 4s ... till 15m and keeps trying every 15m post that.
- Fixes subscriptions not being stopped internally (which can bloat the svc.susbcriptions) when ctx is cancelled during relay connection.
- Also fixes the issue where relays which had connection errors leading to panic on `relay.Close()` (it was an issue in go-nostr where `relay.Connection` is not checked before closing)