### PR TITLE
fix: check relay.connection before closing and stop subscription on ctx cancel

### DIFF
--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -705,31 +705,31 @@ func (svc *Service) startSubscription(ctx context.Context, subscription *Subscri
 		// close relays with connection errors before connecting again
 		// because context expiration has no effect on relays
 		// TODO: Call relay.Connect on already initialized relays
-		if relay != nil && isCustomRelay {
+		if relay != nil && relay.Connection != nil && isCustomRelay {
 			relay.Close()
 		}
 		time.Sleep(time.Duration(waitToReconnectSeconds) * time.Second)
 		relay, isCustomRelay, err = svc.getRelayConnection(ctx, subscription.RelayUrl)
 		if err != nil {
 			// TODO: notify user about relay failure
+			waitToReconnectSeconds = max(waitToReconnectSeconds, 1)
+			waitToReconnectSeconds = min(waitToReconnectSeconds * 2, 900)
 			svc.Logger.WithError(err).WithFields(logrus.Fields{
 				"subscription_id": subscription.ID,
 				"relay_url":       subscription.RelayUrl,
-				}).Errorf("Failed to connect to relay, retrying in %vs...", waitToReconnectSeconds)
-			waitToReconnectSeconds = max(waitToReconnectSeconds, 1)
-			waitToReconnectSeconds = min(waitToReconnectSeconds * 2, 900)
+			}).Errorf("Failed to connect to relay, retrying in %vs...", waitToReconnectSeconds)
 			continue
 		}
 
 		sub, err := relay.Subscribe(ctx, []nostr.Filter{*filter})
 		if err != nil {
 			// TODO: notify user about subscription failure
+			waitToReconnectSeconds = max(waitToReconnectSeconds, 1)
+			waitToReconnectSeconds = min(waitToReconnectSeconds * 2, 900)
 			svc.Logger.WithError(err).WithFields(logrus.Fields{
 				"subscription_id": subscription.ID,
 				"relay_url":       subscription.RelayUrl,
 			}).Errorf("Failed to subscribe to relay, retrying in %vs...", waitToReconnectSeconds)
-			waitToReconnectSeconds = max(waitToReconnectSeconds, 1)
-			waitToReconnectSeconds = min(waitToReconnectSeconds * 2, 900)
 			continue
 		}
 

--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -702,11 +702,17 @@ func (svc *Service) startSubscription(ctx context.Context, subscription *Subscri
 	waitToReconnectSeconds := 0
 
 	for {
-		// close relays with connection errors before connecting again
-		// because context expiration has no effect on relays
-		// TODO: Call relay.Connect on already initialized relays
+		// context expiration has no effect on relays
 		if relay != nil && relay.Connection != nil && isCustomRelay {
 			relay.Close()
+		}
+		if ctx.Err() != nil {
+			svc.Logger.WithFields(logrus.Fields{
+				"subscription_id": subscription.ID,
+				"relay_url":       subscription.RelayUrl,
+			}).Debug("Context canceled, stopping subscription")
+			svc.stopSubscription(subscription)
+			return
 		}
 		time.Sleep(time.Duration(waitToReconnectSeconds) * time.Second)
 		relay, isCustomRelay, err = svc.getRelayConnection(ctx, subscription.RelayUrl)


### PR DESCRIPTION
This fixes subscriptions not being stopped internally (which can bloat the svc.susbcriptions) when ctx is cancelled during relay connection.

This also fixes the issue where relays which had connection errors leading to panic on close as it was an issue in go-nostr where relay.Connection is not checked before closing.