### PR TITLE
fix: retry long-lived subscriptions when relay sends CLOSED

### DIFF
--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -902,7 +902,27 @@ func (svc *Service) processEvents(ctx context.Context, subscription *Subscriptio
 	case <-ctx.Done():
 		return nil
 	case <-relaySubscription.Context.Done():
-		return nil
+		// The subscription's context was cancelled while the parent ctx is
+		// still alive. This is what go-nostr's Subscription.handleClosed
+		// does on receipt of a CLOSED frame from the relay (subscription.go
+		// calls sub.cancel via unsub).
+		//
+		// For long-lived subscriptions (webhook / push notifications, where
+		// RequestEvent is nil) returning nil here causes startSubscription
+		// to break out of its outer for-loop, leaving the DB row open=true
+		// with no goroutine servicing it — recoverable only by a process
+		// restart. Return a non-nil error so the outer loop hits its
+		// "Subscription stopped due to relay error, reconnecting..." path
+		// and re-subscribes.
+		//
+		// For short-lived NIP-47 request subscriptions (RequestEvent != nil)
+		// preserve the existing clean-exit behaviour: the request may
+		// already be in flight, the HTTP handler has its own timeout, and
+		// retrying mid-flight would risk double-sends.
+		if subscription.RequestEvent != nil {
+			return nil
+		}
+		return fmt.Errorf("relay closed subscription: %w", relaySubscription.Context.Err())
 	}
 }
 


### PR DESCRIPTION
## Summary

When the relay sends a NIP-01 `CLOSED` frame, http-nostr's long-lived subscription goroutines (webhook / push notifications) silently exit — the `subscriptions` DB row stays `open=true` but no goroutine is servicing it. Recovery requires a process restart so the boot replay re-spawns goroutines from the DB.

## Failure path

- go-nostr's `Subscription.handleClosed` calls `sub.unsub` which **cancels `sub.Context`** ([subscription.go:135](https://github.com/nbd-wtf/go-nostr/blob/v0.52.3/subscription.go#L135)).
- `processEvents` ([internal/nostr/nostr.go:899-906](../blob/main/internal/nostr/nostr.go#L899-L906)) selects on three contexts. `relaySubscription.Context.Done()` fires first and it returns **`nil`**.
- `startSubscription` ([internal/nostr/nostr.go:783-797](../blob/main/internal/nostr/nostr.go#L783-L797)) sees `err == nil` → enters the `else` branch → for long-lived subs (`RequestEvent == nil`) it just `break`s. No `stopSubscription` is called, so `Open` stays true in the DB; no retry, no log.

The error-arm of the same loop already does the right thing — it logs `"Subscription stopped due to relay error, reconnecting..."` and `continue`s. We just need to route the unexpected-CLOSED case there.

## Impact (2026-05-07 incident)

- Relay sent ~65k CLOSED frames across ~32k distinct wallet pubkeys (Datadog).
- In a single 1h window after the 12:01Z restart: **1,051 logged sub-deaths** vs **10 (re)subscription creates**. The pod converged toward near-zero live subscriptions for users on the default Alby relay.
- Net deficit was hidden because the bug exits silently — no error log, no `Open=false` flip on the DB row.

## Fix

In `processEvents`, distinguish parent-ctx cancellation (shutting down) from sub-ctx cancellation (relay CLOSED). Return a non-nil error in the latter case for long-lived subs so `startSubscription`'s outer loop retries via the existing reconnect path.

```go
case <-relaySubscription.Context.Done():
    if subscription.RequestEvent != nil {
        return nil
    }
    return fmt.Errorf("relay closed subscription: %w", relaySubscription.Context.Err())
```

Long-lived (`RequestEvent == nil` — webhook + push, spawned at lines 154, 583, 646): retry.

Short-lived NIP-47 request subs (`RequestEvent != nil` — spawned at lines 370, 471): keep the existing clean-exit. The request may already be in flight, the HTTP handler has its own timeout, retrying mid-flight risks double-sends.

## Companion fix

The relay-side root cause is fixed in getAlby/nostr-wallet-connect-relay#77 — that PR drops the `nostr.ClosedEnvelope` write on transient db errors. After both land, http-nostr won't see CLOSED frames for db blips at all. This PR is defense-in-depth for any other future cause of CLOSED.

## Test plan

- [ ] CI builds and tests pass.
- [ ] After deploy, force a CLOSED frame from the relay (e.g. by simulating a db error in staging) and verify http-nostr logs `"Subscription stopped due to relay error, reconnecting..."` and the goroutine respawns.
- [ ] Verify normal shutdown path still exits cleanly (parent ctx cancel during processEvents → returns nil → `break`).

Note: the `nostr_test.go` build failure in this repo is **pre-existing on main** (`unknown field subscriptions in struct literal of type Service`) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)