### PR TITLE
fix(relay): set http-nostr user agent on every reconnect

### DIFF
--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -958,7 +958,7 @@ func (svc *Service) relayConnectWithBackoff(ctx context.Context, relayURL string
 			}).Errorf("Context canceled, exiting attempt to connect to relay")
 			return nil, ctx.Err()
 		default:
-			relay, err = nostr.RelayConnect(ctx, relayURL)
+			relay, err = connectToRelay(ctx, relayURL)
 			if err != nil {
 				attempt++
 				// stop reconnecting and return an error if it is a custom relay


### PR DESCRIPTION
## Summary

The relay has a defensive exemption: WebSocket requests with a `User-Agent` starting with `http-nostr/` bypass the per-IP `ConnectionRateLimiter(10/min, burst 10)` (see [`nostr-wallet-connect-relay/cmd/server/main.go:365-376`](https://github.com/getAlby/nostr-wallet-connect-relay/blob/master/cmd/server/main.go#L365-L376)).

http-nostr's `connectToRelay` helper sets that header correctly, but the helper is only used at service startup (`nostr.go:118`). Every reconnect — including all long-lived subscription reconnects after a relay drop — goes through `relayConnectWithBackoff` which called `nostr.RelayConnect` directly with no `User-Agent`.

Effect: on pod boot, http-nostr loads thousands of open subscriptions (~18k observed) and tries to re-establish each one's relay connection. None of those dials carry the exemption header, so the relay rate-limits them. If the startup connect also fails, `svc.Relay` never establishes and the pod stays wedged indefinitely — observed: a pod that ran for 15h with 0 successful relay connects and ~100k failed dials/hour.

## Change

One-line: use `connectToRelay` in `relayConnectWithBackoff` so every reconnect carries the `http-nostr/` User-Agent.

## Test plan

- [ ] CI green
- [ ] Deploy to a single pod and watch `service:http-nostr "Relay connection successful"` log line appear after `Failed to connect to relay` transient failures
- [ ] Verify pod restart no longer triggers sustained 100k+ `Failed to connect` errors/hr in Datadog
- [ ] Confirm `POST /nip47/info` Checkly recovers