### PR TITLE
fix(relay): remove mutex amplifier from getRelayConnection default path

### DIFF
--- a/internal/nostr/nostr.go
+++ b/internal/nostr/nostr.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -52,6 +53,7 @@ type Service struct {
 	Logger             *logrus.Logger
 	subscriptionsMutex sync.Mutex
 	relayMutex         sync.Mutex
+	reconnecting       atomic.Bool // dedupe background reconnects of svc.Relay
 	client             *expo.PushClient
 	subCancelFnMap     map[string]context.CancelFunc
 }
@@ -925,27 +927,49 @@ func (svc *Service) processEvents(ctx context.Context, subscription *Subscriptio
 }
 
 func (svc *Service) getRelayConnection(ctx context.Context, customRelayURL string) (*nostr.Relay, bool, error) {
+	// Custom-relay path unchanged: fresh per-request connection.
 	if customRelayURL != "" && customRelayURL != svc.Cfg.DefaultRelayURL {
 		svc.Logger.WithFields(logrus.Fields{
 			"custom_relay_url": customRelayURL,
 		}).Info("Connecting to custom relay")
 		relay, err := svc.relayConnectWithBackoff(ctx, customRelayURL)
-		return relay, true, err // true means custom and the relay should be closed
+		return relay, true, err
 	}
-	// use mutex otherwise the svc.Relay will be reconnected more than once
-	svc.relayMutex.Lock()
-	defer svc.relayMutex.Unlock()
-	// check if the default relay is active, else reconnect and return the relay
-	if svc.Relay.IsConnected() {
-		return svc.Relay, false, nil
-	} else {
-		svc.Logger.Info("Lost connection to default relay, reconnecting...")
-		relay, err := svc.relayConnectWithBackoff(svc.Ctx, svc.Cfg.DefaultRelayURL)
-		if err == nil {
-			svc.Relay = relay
-		}
-		return svc.Relay, false, err
+
+	// Default-relay path: reuse svc.Relay when alive (fast path, no overhead).
+	// When dead, DO NOT block on a shared mutex+backoff (the old code's
+	// "mutex amplifier" that pinned every concurrent caller until the slow
+	// reconnect finished). Instead: kick off one background reconnect to
+	// rebuild svc.Relay, deduped via CAS, and serve THIS request with a
+	// fresh per-request connection so it doesn't have to wait.
+	if r := svc.Relay; r != nil && r.IsConnected() {
+		return r, false, nil
 	}
+
+	if svc.reconnecting.CompareAndSwap(false, true) {
+		go func() {
+			defer svc.reconnecting.Store(false)
+			svc.Logger.Info("Background reconnect of default relay starting")
+			r, err := svc.relayConnectWithBackoff(svc.Ctx, svc.Cfg.DefaultRelayURL)
+			if err != nil {
+				svc.Logger.WithError(err).Error("Background reconnect of default relay failed")
+				return
+			}
+			svc.relayMutex.Lock()
+			old := svc.Relay
+			svc.Relay = r
+			svc.relayMutex.Unlock()
+			if old != nil {
+				old.Close()
+			}
+			svc.Logger.Info("Background reconnect of default relay succeeded")
+		}()
+	}
+
+	// Fall through: serve this request with a fresh connection so the caller
+	// isn't blocked on the background reconnect's backoff.
+	fresh, err := connectToRelay(ctx, svc.Cfg.DefaultRelayURL)
+	return fresh, true, err
 }
 
 func (svc *Service) relayConnectWithBackoff(ctx context.Context, relayURL string) (relay *nostr.Relay, err error) {


### PR DESCRIPTION
## Summary

`getRelayConnection`'s default-relay branch held `svc.relayMutex` through the *entire* exponential reconnect backoff. When the cached `svc.Relay`'s TCP socket died — relay-pod restart, kube-proxy Service endpoint reshuffle, idle/keepalive timeout, etc. — every concurrent `InfoHandler` / `NIP47Handler` caller stacked behind that mutex while one goroutine slowly worked through `relayConnectWithBackoff`. Result: synchronized 90s timeouts every time the underlying connection had a hiccup.

## What was observed in production (2026-05-27)

- 25 simultaneous `Exiting info subscription without receiving event` entries at exactly the same second
- Checkly synthetic flapping with availability 55-65% over 24h, individual failure clusters of 3 retries × 30s timeout per disconnect event
- 4,583 `Failed to connect to relay` log lines / day, 2,558 `Stopped subscription without receiving event` / day
- 6 disconnect bursts observed in a 4.5h window, ~3 from rolling relay restarts, ~3 from Service endpoint events (no pod restart)

The relay itself, the network path, and the synthetic check were each individually fine. The amplification was purely in this function's code structure.

## Fix

- **Happy path**: when `svc.Relay.IsConnected()` returns true, reuse it — no overhead vs. before.
- **Dead path**: instead of grabbing the mutex and blocking everyone behind a slow `relayConnectWithBackoff`, kick off **one** background reconnect (CAS-deduped via a new `atomic.Bool`), and serve THIS request with a fresh per-request `connectToRelay(ctx, ...)`. Caller closes on defer like the custom-relay branch.
- **Background reconnect** atomically swaps `svc.Relay` (still under `relayMutex`, but only for the pointer swap — *not* the backoff) and closes the old relay.
- Net diff: ~30 lines.

## Verification (local repro stack)

End-to-end with a real `nostr-wallet-connect-relay` + `http-nostr` + Postgres locally, kind:13194 info event seeded for a test wallet pubkey:

| Test                            | Before        | After             |
|---------------------------------|---------------|-------------------|
| 25 concurrent, relay alive      | 70 ms, 25×200 | 92 ms, 25×200  ✅  |
| 25 concurrent, relay killed     | 95 s, 25×000 (curl gave up) | 35 ms, 25×500 with "connection refused" — **2700× faster failure** |
| Recovery after relay returns    | N/A (mutex still blocking) | 81 ms, 25×200, `svc.Relay` reused — automatic via background reconnect ✅ |

Logs confirm:
- `Background reconnect of default relay starting` fires on first dead-state caller
- `Background reconnect of default relay succeeded` fires ~1 s after the relay is reachable again
- Subsequent traffic immediately reuses the rebuilt `svc.Relay` (`isCustomRelay=false` log path)

Long-lived NIP47Handler smoke test (kind:23194 with no responding wallet, kill-relay-mid-flight): in-flight request times out gracefully at its own 90s ctx deadline; concurrent `/nip47/info` calls during the dead window each get HTTP 500 in <1 ms.

`go test ./...` passes.

## Trade-offs

- **+1 background goroutine** during the brief window between disconnect detection and successful reconnect (deduped via CAS).
- **Per-request fresh connection during the dead window only** — for the seconds between disconnect and successful background reconnect, callers each open their own websocket. ~50-200ms in-cluster (we already observed this for the custom-relay path in production). Avoids the previous synchronized-90s-timeout behavior.
- **No regression on the happy path**: `svc.Relay` reuse is identical to before.

## Test plan

- [ ] Local repro passes (✓ verified above)
- [ ] CI green
- [ ] Smoke deploy / canary in mainnet; expect:
  - Checkly availability climbs back to ~99%
  - `Failed to connect to relay` log volume drops sharply (no more synchronized-pileup bursts; only the genuine disconnects produce smaller, transient spikes during background reconnect)
  - No new `Background reconnect of default relay failed` errors at any significant rate

## Related

This addresses the root cause of the production incident investigated 2026-05-27 (manifest as `http-nostr nip47/info` Checkly check flapping at 55-65% availability). The trigger that severs the underlying TCP connections — likely Service endpoint reshuffles on the `nostr-wallet-connect-relay` statefulset — is independent and should be investigated separately on the k8s side. This PR addresses the amplifier, which is the leverage point: a single transient disconnect should no longer punish every concurrent request for 90 seconds.