### PR TITLE
fix: stagger resubscribes so they stop arriving as one burst

### DIFF
--- a/internal/nostr/service.go
+++ b/internal/nostr/service.go
@@ -140,9 +140,9 @@ func NewService(ctx context.Context) (*Service, error) {
 	for _, sub := range openSubscriptions {
 		subscription := sub
 		if subscription.PushToken != "" {
-			svc.startSubscription(subscription, PushSubscriptionType)
+			svc.restoreSubscription(subscription, PushSubscriptionType)
 		} else {
-			svc.startSubscription(subscription, WebhookSubscriptionType)
+			svc.restoreSubscription(subscription, WebhookSubscriptionType)
 		}
 	}
 

--- a/internal/nostr/subscriptions.go
+++ b/internal/nostr/subscriptions.go
@@ -3,6 +3,7 @@ package nostr
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"time"
 
 	expo "github.com/getAlby/exponent-server-sdk-golang/sdk"
@@ -39,6 +40,52 @@ func (svc *Service) startSubscription(subscription Subscription, subscriptionTyp
 	go svc.startPersistentSubscription(subCtx, subscription, subscriptionType)
 }
 
+const (
+	// Width of the randomisation window for the first resubscribe attempt.
+	// Wide enough that a large number of subscriptions resubscribing at once
+	// arrives at a rate a relay can serve, without delaying recovery unduly.
+	resubscribeBaseDelay = 15 * time.Second
+	// Upper bound on that window, however many attempts have failed.
+	resubscribeMaxDelay = 2 * time.Minute
+	// A subscription that stayed up at least this long counts as healthy, so
+	// the next failure starts over from resubscribeBaseDelay.
+	resubscribeStableAfter = 1 * time.Minute
+)
+
+// waitBeforeResubscribe pauses before the caller retries, reporting false if
+// ctx was cancelled while waiting.
+//
+// The pause is drawn uniformly from [0, window) — "full jitter" — instead of
+// being a fixed sleep. Every persistent subscription watches the same shared
+// relay connection, so a single connection failure wakes all of them at the
+// same moment. Retrying immediately, or after an identical delay, sends them
+// back as one synchronised burst, which a relay may not be able to serve; the
+// resulting failures return every subscription to this loop and rebuild the
+// burst. Randomising per subscription decorrelates the retries instead.
+func waitBeforeResubscribe(ctx context.Context, attempt int) bool {
+	timer := time.NewTimer(resubscribeDelay(attempt))
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// resubscribeDelay returns the randomised delay for the given attempt, where
+// attempt is 1 for the first retry. The window doubles per attempt up to
+// resubscribeMaxDelay; the returned value is uniform within it.
+func resubscribeDelay(attempt int) time.Duration {
+	window := resubscribeBaseDelay << min(attempt-1, 5)
+	if window > resubscribeMaxDelay {
+		window = resubscribeMaxDelay
+	}
+
+	return time.Duration(rand.Int63n(int64(window)))
+}
+
 func (svc *Service) startPersistentSubscription(
 	ctx context.Context,
 	subscription Subscription,
@@ -46,8 +93,16 @@ func (svc *Service) startPersistentSubscription(
 ) {
 	filter := svc.subscriptionToFilter(&subscription)
 
+	attempt := 0
+
 	for {
 		if ctx.Err() != nil {
+			return
+		}
+
+		// Skipped on the first pass so a freshly created subscription still
+		// connects immediately.
+		if attempt > 0 && !waitBeforeResubscribe(ctx, attempt) {
 			return
 		}
 
@@ -66,19 +121,31 @@ func (svc *Service) startPersistentSubscription(
 				svc.cancelSubscription(subscription.Uuid)
 				return
 			}
+			attempt++
 			continue
 		}
 
 		relaySub, err := relay.Subscribe(ctx, nostr.Filters{*filter})
 		if err != nil {
+			attempt++
 			continue
 		}
+
+		subscribedAt := time.Now()
 
 		err = svc.processEvents(ctx, subscription, subscriptionType, relaySub)
 		relaySub.Unsub()
 		if err == nil {
 			return
 		}
+
+		// Only a subscription that survived a while indicates the relay is
+		// healthy; without this a relay that closes subscriptions instantly
+		// would keep resetting the backoff and never actually back off.
+		if time.Since(subscribedAt) >= resubscribeStableAfter {
+			attempt = 0
+		}
+		attempt++
 	}
 }
 

--- a/internal/nostr/subscriptions.go
+++ b/internal/nostr/subscriptions.go
@@ -26,7 +26,26 @@ func (svc *Service) cancelSubscription(uuid string) bool {
 	return exists
 }
 
+// startSubscription starts a newly created subscription, which connects
+// straight away.
 func (svc *Service) startSubscription(subscription Subscription, subscriptionType PersistentSubscriptionType) {
+	svc.startSubscriptionAfter(subscription, subscriptionType, 0)
+}
+
+// restoreSubscription starts a subscription that already existed before this
+// process did, as when open subscriptions are reloaded at startup. Those are
+// restored in bulk, so each waits a randomised moment first; otherwise every
+// subscription in the database would connect in the same instant, which is
+// the burst this file's backoff exists to avoid.
+func (svc *Service) restoreSubscription(subscription Subscription, subscriptionType PersistentSubscriptionType) {
+	svc.startSubscriptionAfter(subscription, subscriptionType, resubscribeDelay(1))
+}
+
+func (svc *Service) startSubscriptionAfter(
+	subscription Subscription,
+	subscriptionType PersistentSubscriptionType,
+	initialDelay time.Duration,
+) {
 	subCtx, subCancelFn := context.WithCancel(svc.Ctx)
 
 	svc.subscriptionsMutex.Lock()
@@ -37,7 +56,7 @@ func (svc *Service) startSubscription(subscription Subscription, subscriptionTyp
 	}
 	svc.subCancelFnMap[subscription.Uuid] = subCancelFn
 
-	go svc.startPersistentSubscription(subCtx, subscription, subscriptionType)
+	go svc.startPersistentSubscription(subCtx, subscription, subscriptionType, initialDelay)
 }
 
 const (
@@ -63,7 +82,12 @@ const (
 // resulting failures return every subscription to this loop and rebuild the
 // burst. Randomising per subscription decorrelates the retries instead.
 func waitBeforeResubscribe(ctx context.Context, attempt int) bool {
-	timer := time.NewTimer(resubscribeDelay(attempt))
+	return sleepCtx(ctx, resubscribeDelay(attempt))
+}
+
+// sleepCtx waits for d, reporting false if ctx was cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
 	defer timer.Stop()
 
 	select {
@@ -90,7 +114,12 @@ func (svc *Service) startPersistentSubscription(
 	ctx context.Context,
 	subscription Subscription,
 	subscriptionType PersistentSubscriptionType,
+	initialDelay time.Duration,
 ) {
+	if initialDelay > 0 && !sleepCtx(ctx, initialDelay) {
+		return
+	}
+
 	filter := svc.subscriptionToFilter(&subscription)
 
 	attempt := 0

--- a/internal/nostr/subscriptions_test.go
+++ b/internal/nostr/subscriptions_test.go
@@ -73,6 +73,28 @@ func TestResubscribeDelayIsDecorrelatedAcrossSubscriptions(t *testing.T) {
 	}
 }
 
+// Subscriptions reloaded at startup are restored in bulk, so they carry an
+// initial delay. It must be abandoned when the subscription is cancelled,
+// rather than connecting later regardless.
+func TestStartPersistentSubscriptionAbandonsInitialDelayWhenCancelled(t *testing.T) {
+	svc := &Service{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		svc.startPersistentSubscription(ctx, Subscription{}, WebhookSubscriptionType, time.Hour)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startPersistentSubscription kept waiting after its context was cancelled")
+	}
+}
+
 func TestWaitBeforeResubscribeReturnsFalseWhenContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/nostr/subscriptions_test.go
+++ b/internal/nostr/subscriptions_test.go
@@ -1,0 +1,95 @@
+package nostr
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestResubscribeDelayStaysWithinWindow(t *testing.T) {
+	cases := []struct {
+		attempt int
+		window  time.Duration
+	}{
+		{attempt: 1, window: resubscribeBaseDelay},
+		{attempt: 2, window: 2 * resubscribeBaseDelay},
+		{attempt: 3, window: 4 * resubscribeBaseDelay},
+		// Doubling is capped, so far-out attempts share the max window.
+		{attempt: 9, window: resubscribeMaxDelay},
+		{attempt: 50, window: resubscribeMaxDelay},
+	}
+
+	for _, tc := range cases {
+		for i := 0; i < 500; i++ {
+			got := resubscribeDelay(tc.attempt)
+			if got < 0 || got >= tc.window {
+				t.Fatalf("attempt %d: delay %v outside [0, %v)", tc.attempt, got, tc.window)
+			}
+		}
+	}
+}
+
+func TestResubscribeDelayGrowsWithAttempts(t *testing.T) {
+	// Compare means rather than single draws, which are random by design.
+	mean := func(attempt int) time.Duration {
+		const samples = 2000
+		var total time.Duration
+		for i := 0; i < samples; i++ {
+			total += resubscribeDelay(attempt)
+		}
+		return total / samples
+	}
+
+	first, third := mean(1), mean(3)
+	if third <= first {
+		t.Fatalf("expected later attempts to back off further, got attempt1=%v attempt3=%v", first, third)
+	}
+}
+
+// The regression this guards: every persistent subscription watches the same
+// shared relay connection, so one connection failure wakes them all at once.
+// Retrying after an identical delay would send them back as a synchronised
+// burst rather than a spread.
+func TestResubscribeDelayIsDecorrelatedAcrossSubscriptions(t *testing.T) {
+	const subscriptions = 1000
+
+	buckets := make(map[time.Duration]int)
+	for i := 0; i < subscriptions; i++ {
+		// Round to 100ms buckets: a fixed delay lands every subscription in
+		// one bucket, jitter spreads them across many.
+		buckets[resubscribeDelay(1)/(100*time.Millisecond)]++
+	}
+
+	// Full jitter should populate a good share of the available buckets.
+	// The threshold is deliberately conservative so the test stays stable.
+	if len(buckets) < 20 {
+		t.Fatalf("retries are too clustered: %d distinct buckets across %d subscriptions", len(buckets), subscriptions)
+	}
+
+	for bucket, count := range buckets {
+		if count > subscriptions/4 {
+			t.Fatalf("bucket %v holds %d of %d retries, expected a spread", bucket, count, subscriptions)
+		}
+	}
+}
+
+func TestWaitBeforeResubscribeReturnsFalseWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		// A high attempt number means a long window, so this would block for
+		// minutes if cancellation were not honoured.
+		done <- waitBeforeResubscribe(ctx, 50)
+	}()
+
+	select {
+	case got := <-done:
+		if got {
+			t.Fatal("expected false when the context is already cancelled")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitBeforeResubscribe ignored context cancellation")
+	}
+}


### PR DESCRIPTION
## Problem

`startPersistentSubscription` retried with no delay — every error path did a bare `continue`, sending a failed subscribe straight back round the loop.

That is harmless for one subscription and pathological for all of them at once:

- Every persistent subscription watches the **same shared relay connection** through `processEvents`, which selects on `relaySub.Relay`'s context. When that connection drops, they all return in the same instant and resubscribe together.
- `getRelayConnection`'s singleflight compounds it: callers block on one shared reconnect and are then released **simultaneously**, so retries aren't merely concurrent, they're phase-locked.

A relay that can't serve the whole burst fails part of it, which returns those subscriptions to this loop and rebuilds the burst — so the cycle sustains itself rather than settling.

## Change

**1. Jittered retry backoff.** Retries wait a duration drawn uniformly from `[0, window)` — full jitter — which decorrelates them.

- Window starts at 15s, doubles per consecutive failure, capped at 2 minutes.
- The first connect is never delayed, so newly created subscriptions are unaffected.
- The attempt counter resets only once a subscription has stayed up a full minute. Without that, a relay closing subscriptions immediately would keep resetting the counter and never actually back off.

The bare `continue` on the connect/subscribe error paths also meant a persistently failing relay was retried in a tight loop; the same backoff now bounds that too.

**2. Staggered startup restore.** Backoff alone doesn't cover startup: reloading open subscriptions calls `startSubscription` for every row in a tight loop, and the first connect is deliberately never delayed — so a restart reconnected every subscription in the database in the same instant. Same burst, triggered by a restart instead of a dropped connection.

The two cases are now split:

- `startSubscription` — unchanged, connects immediately. Used by the handlers when a subscription is created, so nothing a caller waits on gets slower.
- `restoreSubscription` — used only by the startup reload. Draws the same jittered delay a first retry would and waits it out first. The wait is abandoned if the subscription is cancelled while pending, so shutdown or unsubscribe during startup doesn't leave work queued behind a timer.

Without this, deploying this PR would itself have produced one final unjittered burst on startup, and again on every restart.

## Tests

`internal/nostr/subscriptions_test.go`:

- delay stays within the expected window, including that the doubling is capped
- backoff grows across attempts (compares means, since single draws are random by design)
- **retries are decorrelated** — 1,000 subscriptions spread across many time buckets rather than landing in one. This is the actual regression guard: a fixed delay puts every subscription in a single bucket and fails the test.
- a pending startup delay is abandoned when the subscription's context is cancelled
- context cancellation is honoured while waiting

Full suite passes; `gofmt`, `go build`, `go vet` clean.

## Notes

Full jitter (uniform over the whole window, rather than a fixed delay plus a small random component) is the variant that decorrelates best when the whole population wakes together, which is exactly this case.

Window sizing is a judgement call — 15s trades a little recovery latency for a wide spread. It never applies to a newly created subscription, only to retries and to bulk startup restores. Happy to tune.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for persistent subscriptions after service restarts.
  * Added resilient retry behavior with randomized delays to prevent simultaneous reconnection attempts.
  * Retry delays increase after repeated failures and reset after stable connections.
  * Ongoing waits now stop promptly when cancellation occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->