### PR TITLE
fix: guard resubscribeDelay against inputs that would panic

### DIFF
--- a/internal/nostr/subscriptions.go
+++ b/internal/nostr/subscriptions.go
@@ -101,10 +101,24 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 // resubscribeDelay returns the randomised delay for the given attempt, where
 // attempt is 1 for the first retry. The window doubles per attempt up to
 // resubscribeMaxDelay; the returned value is uniform within it.
+//
+// Both bounds are enforced here rather than left to callers. attempt < 1 would
+// shift by a negative amount and rand.Int63n requires a positive argument, and
+// either one panics rather than degrading. An unrecovered panic in a
+// subscription goroutine takes the process down, which drops every
+// subscription at once - the synchronised reconnect this backoff exists to
+// prevent.
 func resubscribeDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+
 	window := resubscribeBaseDelay << min(attempt-1, 5)
 	if window > resubscribeMaxDelay {
 		window = resubscribeMaxDelay
+	}
+	if window <= 0 {
+		return 0
 	}
 
 	return time.Duration(rand.Int63n(int64(window)))

--- a/internal/nostr/subscriptions_test.go
+++ b/internal/nostr/subscriptions_test.go
@@ -29,6 +29,26 @@ func TestResubscribeDelayStaysWithinWindow(t *testing.T) {
 	}
 }
 
+// attempt values below 1 would shift by a negative amount, which panics at
+// runtime rather than returning a bad value. Nothing calls it that way today,
+// but the guard against it lives here rather than in the callers.
+func TestResubscribeDelayHandlesAttemptsBelowOne(t *testing.T) {
+	for _, attempt := range []int{0, -1, -1000} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("resubscribeDelay(%d) panicked: %v", attempt, r)
+				}
+			}()
+
+			got := resubscribeDelay(attempt)
+			if got < 0 || got >= resubscribeBaseDelay {
+				t.Fatalf("resubscribeDelay(%d) = %v, want within [0, %v)", attempt, got, resubscribeBaseDelay)
+			}
+		}()
+	}
+}
+
 func TestResubscribeDelayGrowsWithAttempts(t *testing.T) {
 	// Compare means rather than single draws, which are random by design.
 	mean := func(attempt int) time.Duration {


### PR DESCRIPTION
Follow-up to #153, from reviewing it after merge.

## The problem

`resubscribeDelay(attempt)` shifts by `attempt-1`, so any `attempt` below 1 shifts by a **negative amount** — which is a runtime panic, not a bad return value:

```
attempt=1 -> 15s
attempt=0 -> panic: runtime error: negative shift amount
```

`rand.Int63n` has the same shape: it panics on a non-positive argument, so setting `resubscribeBaseDelay = 0` to disable jitter would panic rather than degrade to no delay.

## Why guard it rather than document it

Neither is reachable today — the only callers pass a literal `1`, or are guarded by `attempt > 0`. But **that guard lives in `startPersistentSubscription`, a different function from the arithmetic it protects.** A new caller, or a refactor that moves the check, reintroduces it silently.

The blast radius is what makes it worth a clamp. An unrecovered panic in a goroutine takes down the **whole process**. http-nostr runs a single replica, so every subscription drops at once and reconnects together when it restarts — the synchronised burst #153 exists to prevent. A one-line arithmetic slip would undo the fix it lives inside.

Both bounds now belong to the function that needs them.

## Test

`TestResubscribeDelayHandlesAttemptsBelowOne` covers `0`, `-1`, `-1000`. Verified it's a real regression test, not a vacuous one — with the clamp removed:

```
--- FAIL: TestResubscribeDelayHandlesAttemptsBelowOne
    resubscribeDelay(0) panicked: runtime error: negative shift amount
```

and it passes with the clamp restored. Full suite green, `gofmt`/`go build`/`go vet` clean.

## Deploy note

Worth landing **before** the deployment pin is moved off the branch build, so production goes from `fix-stagger-resubscribe-5d15f56` to a `main-` tag once rather than twice.